### PR TITLE
chore(lock): no more package-lock.json file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
## No more `package-lock.json` file

### Description of the Change

1e1b996 — chore(lock): no more package-lock.json file