### PR TITLE
test(travis): refer to the new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gulp Drupal Stack
 ![gulp-drupal-stack-banner](banner.png)
 
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/ovh/ux)
-[![travis](https://travis-ci.org/ovh-ux/gulp-drupal-stack.svg?branch=master)](https://travis-ci.org/ovh-ux/gulp-drupal-stack)
+[![travis](https://travis-ci.org/ovh/gulp-drupal-stack.svg?branch=master)](https://travis-ci.org/ovh/gulp-drupal-stack)
 [![Documentation Status](https://readthedocs.org/projects/gulp-drupal-stack/badge/?version=latest)](http://gulp-drupal-stack.readthedocs.io/en/latest/?badge=latest)
 
 


### PR DESCRIPTION
repository has been transferred from `ovh-ux` organization to `ovh`

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>